### PR TITLE
Fix include of <cmath>

### DIFF
--- a/DNAconsts.h
+++ b/DNAconsts.h
@@ -69,7 +69,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <assert.h>
 #include <time.h>
 #include <list>
-#include <math.h>
+#include <cmath>
 #include <unordered_map>
 #include <unordered_set>
 #include <fcntl.h>

--- a/containers.h
+++ b/containers.h
@@ -24,8 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "include/robin_set.h"
 #include "include/robin_hood.h"
 
-//#include <math.h>
-
 
 //fwd declaration
 class UClinks;


### PR DESCRIPTION
On case-insensitive file-system (e.g. under macOS), `math.h` conflicts with sdm's `Math.h`