### PR TITLE
Fix number of sequences read in multi threaded run

### DIFF
--- a/Statistics.cpp
+++ b/Statistics.cpp
@@ -23,7 +23,9 @@ void collectstats::addStats(shared_ptr<collectstats> cs, vector<int>& idx) {
     PrimerRevFail += cs->PrimerRevFail;
     minL += cs->minL; minLqualTrim += cs->minLqualTrim; TagFail += cs->TagFail;
     MaxAmb += cs->MaxAmb; QualWin += cs->QualWin;
-    Trimmed += cs->Trimmed; AccErrTrimmed += cs->AccErrTrimmed; total += cs->total;
+    Trimmed += cs->Trimmed;
+    AccErrTrimmed += cs->AccErrTrimmed;
+    total.fetch_add(cs->total.load(), std::memory_order_relaxed);
     QWinTrimmed += cs->QWinTrimmed;
     totalRejected += cs->totalRejected;
     fail_correct_BC += cs->fail_correct_BC; suc_correct_BC += cs->suc_correct_BC;

--- a/Statistics.h
+++ b/Statistics.h
@@ -7,6 +7,7 @@
 
 #include "DNAconsts.h"
 #include "InputStream.h"
+#include <atomic>
 
 class Statistics {
 public:
@@ -226,10 +227,13 @@ public:
     unsigned int maxL, PrimerFail, AvgQual, HomoNT;
     unsigned int PrimerRevFail; //Number of sequences, where RevPrimer was detected (and removed)
     unsigned int minL, minLqualTrim, TagFail, MaxAmb, QualWin;
-    unsigned int Trimmed, AccErrTrimmed, QWinTrimmed, total, totalMid, totalRejected;
+    unsigned int Trimmed, AccErrTrimmed, QWinTrimmed, totalMid;
+    std::atomic<unsigned int> total;
+    std::atomic<unsigned int> totalRejected;
     unsigned int fail_correct_BC, suc_correct_BC, failedDNAread;
     unsigned int adapterRem, RevPrimFound;
-    uint total2, totalSuccess;
+    std::atomic<unsigned int> total2;
+    unsigned int totalSuccess;
     uint DerepAddBadSeq;
     //binomial error model
     unsigned int BinomialErr;


### PR DESCRIPTION
Fix non-deterministic read count due to missing atomic counter updates in multi threaded mode

While all the sequences of a pair of files were read, the reporting was missing some. With this fix the reporting matches the number of sequences read